### PR TITLE
Fix for Rmpq_add_z(), Rmpq_sub_z(), Rmpq_z_sub() and Rmpq_z_div().

### DIFF
--- a/GMPq.xs
+++ b/GMPq.xs
@@ -559,7 +559,7 @@ SV * get_refcnt(pTHX_ SV * s) {
 }
 
 void Rmpq_add_z(mpq_t * rop, mpq_t * op, mpz_t * z) {
-     if(*rop == *op) {
+     if (*rop == *op) {
         mpz_addmul(mpq_numref(*op), mpq_denref(*op), *z);
      } else {
         mpq_set(*rop, *op);
@@ -604,9 +604,18 @@ void Rmpq_div_z(mpq_t * rop, mpq_t * op, mpz_t * z) {
 }
 
 void Rmpq_z_div(mpq_t * rop, mpz_t * z, mpq_t * op) {
-     mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
-     mpz_set(mpq_denref(*rop), mpq_numref(*op));
-     mpq_canonicalize(*rop);
+     if (*rop == *op) {
+        mpz_t temp;
+        mpz_init(temp);
+        mpq_get_num(temp, *op);
+        mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
+        mpz_set(mpq_denref(*rop), temp);
+        mpz_clear(temp);
+     } else {
+        mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
+        mpz_set(mpq_denref(*rop), mpq_numref(*op));
+    }
+    mpq_canonicalize(*rop);
 }
 
 void Rmpq_pow_ui(mpq_t * rop, mpq_t * op, unsigned long ui) {

--- a/GMPq.xs
+++ b/GMPq.xs
@@ -559,32 +559,32 @@ SV * get_refcnt(pTHX_ SV * s) {
 }
 
 void Rmpq_add_z(mpq_t * rop, mpq_t * op, mpz_t * z) {
-     if (*rop == *op) {
+    if (rop == op) {
         mpz_addmul(mpq_numref(*op), mpq_denref(*op), *z);
-     } else {
+    } else {
         mpq_set(*rop, *op);
         mpz_addmul(mpq_numref(*rop), mpq_denref(*rop), *z);
     }
 }
 
 void Rmpq_sub_z(mpq_t * rop, mpq_t * op, mpz_t * z) {
-     if (*rop == *op) {
+    if (rop == op) {
         mpz_submul(mpq_numref(*op), mpq_denref(*op), *z);
-     } else {
+    } else {
         mpq_set(*rop, *op);
         mpz_submul(mpq_numref(*rop), mpq_denref(*rop), *z);
      }
 }
 
 void Rmpq_z_sub(mpq_t * rop, mpz_t * z, mpq_t * op) {
-     if (*rop == *op) {
+    if (rop == op) {
         mpz_t temp;
         mpz_init(temp);
         mpz_mul(temp, *z, mpq_denref(*op));
         mpz_sub(temp, temp, mpq_numref(*op));
         mpz_set(mpq_numref(*op), temp);
         mpz_clear(temp);
-     } else {
+    } else {
         mpq_set(*rop, *op);
         mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
         mpz_sub(mpq_numref(*rop), mpq_numref(*rop), mpq_numref(*op));
@@ -604,14 +604,14 @@ void Rmpq_div_z(mpq_t * rop, mpq_t * op, mpz_t * z) {
 }
 
 void Rmpq_z_div(mpq_t * rop, mpz_t * z, mpq_t * op) {
-     if (*rop == *op) {
+    if (rop == op) {
         mpz_t temp;
         mpz_init(temp);
         mpq_get_num(temp, *op);
         mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
         mpz_set(mpq_denref(*rop), temp);
         mpz_clear(temp);
-     } else {
+    } else {
         mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
         mpz_set(mpq_denref(*rop), mpq_numref(*op));
     }

--- a/GMPq.xs
+++ b/GMPq.xs
@@ -559,21 +559,36 @@ SV * get_refcnt(pTHX_ SV * s) {
 }
 
 void Rmpq_add_z(mpq_t * rop, mpq_t * op, mpz_t * z) {
-     mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
-     mpz_add(mpq_numref(*rop), mpq_numref(*op), mpq_numref(*rop));
-     mpz_set(mpq_denref(*rop), mpq_denref(*op));
+     if(*rop == *op) {
+        mpz_addmul(mpq_numref(*op), mpq_denref(*op), *z);
+     } else {
+        mpq_set(*rop, *op);
+        mpz_addmul(mpq_numref(*rop), mpq_denref(*rop), *z);
+    }
 }
 
 void Rmpq_sub_z(mpq_t * rop, mpq_t * op, mpz_t * z) {
-     mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
-     mpz_sub(mpq_numref(*rop), mpq_numref(*op), mpq_numref(*rop));
-     mpz_set(mpq_denref(*rop), mpq_denref(*op));
+     if (*rop == *op) {
+        mpz_submul(mpq_numref(*op), mpq_denref(*op), *z);
+     } else {
+        mpq_set(*rop, *op);
+        mpz_submul(mpq_numref(*rop), mpq_denref(*rop), *z);
+     }
 }
 
 void Rmpq_z_sub(mpq_t * rop, mpz_t * z, mpq_t * op) {
-     mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
-     mpz_sub(mpq_numref(*rop), mpq_numref(*rop), mpq_numref(*op));
-     mpz_set(mpq_denref(*rop), mpq_denref(*op));
+     if (*rop == *op) {
+        mpz_t temp;
+        mpz_init(temp);
+        mpz_mul(temp, *z, mpq_denref(*op));
+        mpz_sub(temp, temp, mpq_numref(*op));
+        mpz_set(mpq_numref(*op), temp);
+        mpz_clear(temp);
+     } else {
+        mpq_set(*rop, *op);
+        mpz_mul(mpq_numref(*rop), mpq_denref(*op), *z);
+        mpz_sub(mpq_numref(*rop), mpq_numref(*rop), mpq_numref(*op));
+     }
 }
 
 void Rmpq_mul_z(mpq_t * rop, mpq_t * op, mpz_t * z) {


### PR DESCRIPTION
This pull-request includes fixes for Rmpq_add_z(), Rmpq_sub_z() and Rmpq_z_sub() when `$rop` is the same object as `$op`. (i.e. when the operation is done in-place).

```perl
#!/usr/bin/perl

use strict;
use warnings;

use Math::GMPq;
use Math::GMPz;
use Test::More;

plan tests => 30;

{
    my $q = Math::GMPq->new('42');
    my $z = Math::GMPz->new('3');
    Math::GMPq::Rmpq_add_z($q, $q, $z);
    is("$q", 45, 'Rmpq_add_z($q, $q, $z)');
}

{
    my $q = Math::GMPq->new('42');
    my $z = Math::GMPz->new('3');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_add_z($r, $q, $z);
    is("$r", 45, 'Rmpq_add_z($r, $q, $z)');
    is("$q", '42');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('100');
    Math::GMPq::Rmpq_add_z($q, $q, $z);
    is("$q", '1205/12', 'Rmpq_add_z($q, $q, $z)');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('100');
    Math::GMPq::Rmpq_add_z($q, $q, $z);
    is("$q", '1195/12', 'Rmpq_add_z($q, $q, $z)');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('-100');
    Math::GMPq::Rmpq_add_z($q, $q, $z);
    is("$q", '-1195/12', 'Rmpq_add_z($q, $q, $z)');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('-100');
    Math::GMPq::Rmpq_add_z($q, $q, $z);
    is("$q", '-1205/12', 'Rmpq_add_z($q, $q, $z)');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_add_z($r, $q, $z);
    is("$r", '1205/12', 'Rmpq_add_z($r, $q, $z)');
    is("$q", '5/12');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_add_z($r, $q, $z);
    is("$r", '1195/12', 'Rmpq_add_z($r, $q, $z)');
    is("$q", '-5/12');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('-100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_add_z($r, $q, $z);
    is("$r", '-1205/12', 'Rmpq_add_z($r, $q, $z)');
    is("$q", '-5/12');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('-100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_add_z($r, $q, $z);
    is("$r", '-1195/12', 'Rmpq_add_z($r, $q, $z)');
    is("$q", '5/12');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('100');
    Math::GMPq::Rmpq_z_sub($q, $z, $q);
    is("$q", '1195/12', 'Rmpq_z_sub($q, $z, $q)');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('-100');
    Math::GMPq::Rmpq_z_sub($q, $z, $q);
    is("$q", '-1205/12', 'Rmpq_z_sub($q, $z, $q)');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('-100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_z_sub($r, $z, $q);
    is("$r", '-1205/12', 'Rmpq_z_sub($r, $z, $q)');
    is("$q", '5/12');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('-100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_z_sub($r, $z, $q);
    is("$r", '-1205/12', 'Rmpq_z_sub($r, $z, $q)');
    is("$q", '5/12');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('-100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_z_sub($r, $z, $q);
    is("$r", '-1195/12', 'Rmpq_z_sub($r, $z, $q)');
    is("$q", '-5/12');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_z_sub($r, $z, $q);
    is("$r", '1205/12', 'Rmpq_z_sub($r, $z, $q)');
    is("$q", '-5/12');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('100');
    Math::GMPq::Rmpq_z_sub($q, $z, $q);
    is("$q", '1205/12', 'Rmpq_z_sub($q, $z, $q)');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('-100');
    Math::GMPq::Rmpq_z_sub($q, $z, $q);
    is("$q", '-1195/12', 'Rmpq_z_sub($q, $z, $q)');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('100');
    Math::GMPq::Rmpq_sub_z($q, $q, $z);
    is("$q", '-1195/12', 'Rmpq_sub_z($q, $q, $z)');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_sub_z($r, $q, $z);
    is("$r", '-1195/12', 'Rmpq_sub_z($r, $q, $z)');
    is("$q", '5/12');
}
```

Tests for Rmpq_z_div():

```perl
#!/usr/bin/perl

use strict;
use warnings;

use Math::GMPz;
use Math::GMPq;

use Test::More;

plan tests => 6;

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('100');
    Math::GMPq::Rmpq_z_div($q, $z, $q);
    is("$q", '240');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('100');
    my $r = Math::GMPq->new('0');
    Math::GMPq::Rmpq_z_div($r, $z, $q);
    is("$r", '240');
    is("$q", '5/12');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('42');
    Math::GMPq::Rmpq_z_div($q, $z, $q);
    is("$q", '-504/5');
}

{
    my $q = Math::GMPq->new('-5/12');
    my $z = Math::GMPz->new('-42');
    Math::GMPq::Rmpq_z_div($q, $z, $q);
    is("$q", '504/5');
}

{
    my $q = Math::GMPq->new('5/12');
    my $z = Math::GMPz->new('-42');
    Math::GMPq::Rmpq_z_div($q, $z, $q);
    is("$q", '-504/5');
}
```